### PR TITLE
feat: Include v4 address

### DIFF
--- a/docs/pages/contracts/v4/resources/addresses.mdx
+++ b/docs/pages/contracts/v4/resources/addresses.mdx
@@ -1,7 +1,29 @@
 import { Callout } from 'vocs/components'
 
-# Addresses (Work in progress)
+# Addresses 
 
 <Callout type="note">
-  Stay tuned! page will be updated when contracts are deployed at Sepolia!
+  PCS v4 have been deployed on Sepolia
 </Callout>
+
+--- 
+
+From https://github.com/pancakeswap/pancake-v4-core
+
+| Contract | Address  |
+| ------ | ------ |
+| Vault | 0x42A228A7fB040033Dc49FdD5ed909F2cA742271D |
+| CLPoolManager | 0xC6A2Db661D5a5690172d8eB0a7DEA2d3008665A3 |
+| BinPoolManager | https://github.com/pancakeswap/pancake-v4-hooks |
+
+---- 
+
+From https://github.com/pancakeswap/pancake-v4-periphery
+
+| Contract | Address  |
+| ------ | ------ |
+| NonfungibleTokenPositionDescriptorOffChain | 0x9372dAFFB1018a82Ff7bAe6f50666bc21A2De5d1 |
+| NonFungiblePositionManager | 0xa757029D3f3273F920765C8eDaC16703FCc86653 |
+| ClSwapRouter | 0x1A96e1bEFec4666B75DFEe48Ed2C4b7F6E728488 |
+| BinFungiblePositionManager | 0x6E6B30d65D605DAa4CaC65eB270100Ecca36b140 | 
+| BinSwapRouter | 0x6B59181eBD1a3C864AfA41233445B7972f6C1A9e | 

--- a/docs/pages/contracts/v4/resources/addresses.mdx
+++ b/docs/pages/contracts/v4/resources/addresses.mdx
@@ -14,7 +14,7 @@ From https://github.com/pancakeswap/pancake-v4-core
 | ------ | ------ |
 | Vault | 0x42A228A7fB040033Dc49FdD5ed909F2cA742271D |
 | CLPoolManager | 0xC6A2Db661D5a5690172d8eB0a7DEA2d3008665A3 |
-| BinPoolManager | https://github.com/pancakeswap/pancake-v4-hooks |
+| BinPoolManager | 0xFCa69D6639293799A650dB7D273bc688bAF71FA7 |
 
 ---- 
 

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -78,7 +78,7 @@ export default defineConfig({
                 link: '/contracts/v4/resources/github',
               },
               {
-                text: '<WIP> Addresses',
+                text: 'Addresses',
                 link: '/contracts/v4/resources/addresses',
               },
             ],


### PR DESCRIPTION
## Description

Current v4 has been deployed on Sepolia, see

- https://github.com/pancakeswap/pancake-v4-core/pull/7
- https://github.com/pancakeswap/pancake-v4-periphery/pull/2

This PR includes the address in our developer doc