### PR TITLE
chore: updated v4 address

### DIFF
--- a/docs/pages/contracts/v4/resources/addresses.mdx
+++ b/docs/pages/contracts/v4/resources/addresses.mdx
@@ -3,27 +3,26 @@ import { Callout } from 'vocs/components'
 # Addresses 
 
 <Callout type="note">
-  PCS v4 have been deployed on Sepolia
+  PCS v4 have been deployed on Sepolia and BSC testnet
 </Callout>
 
 --- 
 
 From https://github.com/pancakeswap/pancake-v4-core
 
-| Contract | Address  |
-| ------ | ------ |
-| Vault | 0x42A228A7fB040033Dc49FdD5ed909F2cA742271D |
-| CLPoolManager | 0xC6A2Db661D5a5690172d8eB0a7DEA2d3008665A3 |
-| BinPoolManager | 0xFCa69D6639293799A650dB7D273bc688bAF71FA7 |
+| Contract | Sepolia  | BSC Testnet |
+| ------ | ------ | ------ |
+| Vault | 0x80b1A60966b21be848ab1A515CdCF944d13C48Cc | 0x1b896893dfc86bb67Cf57767298b9073D2c1bA2c | 
+| CLPoolManager | 0xbFfE39cDD04f0183e0493c1Deb6E275c5cf84AdF | 0xb3b166Ac12cd6C1e0093Cbde5810343DC28F17fD | 
+| BinPoolManager | 0x54Ee7e7da9e4aC5761855c4b5f1d8F8b95Dc13ff | 0x20d39ad9C930fa7F0C90232101CCb9028280d063 |
 
 ---- 
 
 From https://github.com/pancakeswap/pancake-v4-periphery
 
-| Contract | Address  |
-| ------ | ------ |
-| NonfungibleTokenPositionDescriptorOffChain | 0x9372dAFFB1018a82Ff7bAe6f50666bc21A2De5d1 |
-| NonFungiblePositionManager | 0xa757029D3f3273F920765C8eDaC16703FCc86653 |
-| ClSwapRouter | 0x1A96e1bEFec4666B75DFEe48Ed2C4b7F6E728488 |
-| BinFungiblePositionManager | 0x6E6B30d65D605DAa4CaC65eB270100Ecca36b140 | 
-| BinSwapRouter | 0x6B59181eBD1a3C864AfA41233445B7972f6C1A9e | 
+| Contract | Sepolia  | BSC Testnet |
+| ------ | ------ | ------ |
+| NonFungiblePositionManager | 0xB4f95604B4438b1dd6d696aF515B36bc870a64FE | 0x11f715c1E547fe657A6AB7a68FD988B953600652 |
+| ClSwapRouter | 0xdd4f24B3B49D67DF8964A99d67De08E0003Ef295 | 0x56200961C16E32cA197B772fade66B58676d346D |
+| BinFungiblePositionManager | 0x42534Faa23f3C929b6bE13dbED3C4bF8DCd714C4 | 0x14a17dCf6d9BC6a5055D0aC58Deb64859643a196 |
+| BinSwapRouter | 0x9b6fe628e21f25BdBcd19c40947a91B35CEc2d6a | 0x0F129A0097D27705D35b81D918f49978E0Ed5E72 |


### PR DESCRIPTION
Include updated v4 address on testnet (Sepolia and BSC)