### PR TITLE
feat: add certik blog for hook security

### DIFF
--- a/docs/pages/contracts/infinity/guides/develop-a-hook.mdx
+++ b/docs/pages/contracts/infinity/guides/develop-a-hook.mdx
@@ -214,3 +214,11 @@ key = PoolKey({
 ### Step 5: Verify
 
 Run `forge test` to verify test passing. 
+
+## Next step
+
+Explore more guides in our developer documentation:
+- [Taking a fee via hook](/contracts/infinity/guides/hook-examples/taking-fee-via-hook) 
+- [Overwrite amm-curve via hook](/contracts/infinity/guides/hook-examples/overwriting-amm-curve)
+
+For additional insights, we recommend reading [this blog post by Certik](https://www.certik.com/resources/blog/pancakeswap-infinity-hooks-security-considerations) on security considerations for hooks.


### PR DESCRIPTION
This PR add a link to Certik's blog post on hook's security concern