### PR TITLE
fix: close currency action hex wrong in docs

### DIFF
--- a/docs/pages/contracts/infinity/guides/manage-liquidity.mdx
+++ b/docs/pages/contracts/infinity/guides/manage-liquidity.mdx
@@ -64,8 +64,8 @@ The `bytes calldata payload` in `modifyLiquidities` is `abi.encode(actions, para
 Given `actions = 0x021212`, it would mean 3 actions processed in order:
 
 1. `0x02`: `CL_MINT_POSITION`
-2. `0x17`: `CLOSE_CURRENCY`
-3. `0x17`: `CLOSE_CURRENCY`
+2. `0x12`: `CLOSE_CURRENCY`
+3. `0x12`: `CLOSE_CURRENCY`
 
 With 3 actions, it would mean `bytes[] params` of length = 3.
 


### PR DESCRIPTION
The close currency action hex is currently wrong in the docs about managing liquidity in PancakeSwap infinity:

<img width="573" height="161" alt="Screenshot 2025-08-22 at 3 24 19 PM" src="https://github.com/user-attachments/assets/5cf5fa8d-332e-4efd-a070-35a28563ca6f" />

Just updated it to "0x12" following the Periphery code:
```sol
uint256 internal constant CLOSE_CURRENCY = 0x12;
```