### PR TITLE
Correct token name in the liquidity pool

### DIFF
--- a/docs/pages/contracts/v2/router-v2.md
+++ b/docs/pages/contracts/v2/router-v2.md
@@ -72,7 +72,7 @@ Adds liquidity to a BEP20⇄BEP20 pool.
 | tokenA         | `address` | The contract address of one token from your liquidity pair.       |
 | tokenB         | `address` | The contract address of the other token from your liquidity pair. |
 | amountADesired | `uint`    | The amount of tokenA you'd like to provide as liquidity.          |
-| amountBDesired | `uint`    | The amount of tokenA you'd like to provide as liquidity.          |
+| amountBDesired | `uint`    | The amount of tokenB you'd like to provide as liquidity.          |
 | amountAMin     | `uint`    | The minimum amount of tokenA to provide (slippage impact).        |
 | amountBMin     | `uint`    | The minimum amount of tokenB to provide (slippage impact).        |
 | to             | `address` | Address of LP Token recipient.                                    |


### PR DESCRIPTION
The token name in the liquidity pool is wrong. Use this change to make it right.