### PR TITLE
fix: update stale developer documentation

### DIFF
--- a/docs/pages/apis/subgraph.md
+++ b/docs/pages/apis/subgraph.md
@@ -13,8 +13,7 @@ Code: [https://github.com/pancakeswap/pancake-subgraph](https://github.com/panca
    - BSC https://nodereal.io/meganode/api-marketplace/pancakeswap-graphql
    - ETH https://thegraph.com/explorer/subgraphs/9opY17WnEPD4REcC43yHycQthSeUMQE26wyoeMjZTLEx?view=Query&chain=arbitrum-one
    - ARB https://thegraph.com/explorer/subgraphs/EsL7geTRcA3LaLLM9EcMFzYbUgnvf8RixoEEGErrodB3?view=Query&chain=arbitrum-one
-   - ARB GRO https://api.thegraph.com/subgraphs/name/chef-jojo/exchange-v2-arb-goerli
-   - Polygon zkEVM https://thegraph.com/explorer/subgraphs/37WmH5kBu6QQytRpMwLJMGPRbXvHgpuZsWqswW4Finc2?view=Query&chain=arbitrum-one
+   <!--  Polygon zkEVM and Arbitrum Goerli subgraphs have been deprecated -->
    - zkSync https://thegraph.com/explorer/subgraphs/6dU6WwEz22YacyzbTbSa3CECCmaD8G7oQ8aw6MYd5VKU?view=Query&chain=arbitrum-one
    - Linea https://thegraph.com/explorer/subgraphs/Eti2Z5zVEdARnuUzjCbv4qcimTLysAizsqH3s6cBfPjB?view=Query&chain=arbitrum-one
    - Base https://thegraph.com/explorer/subgraphs/2NjL7L4CmQaGJSacM43ofmH6ARf6gJoBeBaJtz9eWAQ9?view=Query&chain=arbitrum-one
@@ -49,7 +48,6 @@ Code: [https://github.com/pancakeswap/pancake-subgraph](https://github.com/panca
 15. **MasterChef (v3)**: Tracks data for MasterChefV3.
     - BSC https://thegraph.com/explorer/subgraphs/QProcZexB8KYHueG55aoLhBmwnLXExxopq7CUnFkjMv?view=Query&chain=arbitrum-one
     - ETH https://thegraph.com/explorer/subgraphs/9psTWtnVVQwSHUVRtCuR8985UfzotdtdZwVt8K9kJGeg?view=Query&chain=arbitrum-one
-    - Polygon zkEVM https://thegraph.com/explorer/subgraphs/GY319RL3CwRYq4LvTcGnE2ftVtWfM7D7FLzsy21GFYUb?view=Query&chain=arbitrum-one
     - ARB https://thegraph.com/explorer/subgraphs/2fq9U1dYX1bxuu6D3HuZcfyZSBxPHd8yWduJnVoxNjSP?view=Query&chain=arbitrum-one
     - zkSync https://thegraph.com/explorer/subgraphs/BnTM866GHTEyhxzrSmqnCdDAEixc34R87SnZaxH4BChy?view=Query&chain=arbitrum-one
     - Base https://thegraph.com/explorer/subgraphs/3oYoAoCJMV2ZyZSTpg6cUS1gKTzcc2cjmCVfpNyWZVmr?view=Query&chain=arbitrum-one
@@ -58,10 +56,9 @@ Code: [https://github.com/pancakeswap/pancake-subgraph](https://github.com/panca
     - BSC https://thegraph.com/explorer/subgraphs/Hv1GncLY5docZoGtXjo4kwbTvxm3MAhVZqBZE4sUT9eZ?view=Query&chain=arbitrum-one
     - ETH https://thegraph.com/explorer/subgraphs/CJYGNhb7RvnhfBDjqpRnD3oxgyhibzc7fkAMa38YV3oS?view=Query&chain=arbitrum-one
     - ARB https://thegraph.com/explorer/subgraphs/251MHFNN1rwjErXD2efWMpNS73SANZN8Ua192zw6iXve?view=Query&chain=arbitrum-one
-    - Polygon zkEVM https://thegraph.com/explorer/subgraphs/7HroSeAFxfJtYqpbgcfAnNSgkzzcZXZi6c75qLPheKzQ?view=Query&chain=arbitrum-one
     - zkSync https://thegraph.com/explorer/subgraphs/3dKr3tYxTuwiRLkU9vPj3MvZeUmeuGgWURbFC72ZBpYY?view=Query&chain=arbitrum-one
     - Linea https://thegraph.com/explorer/subgraphs/6gCTVX98K3A9Hf9zjvgEKwjz7rtD4C1V173RYEdbeMFX?view=Query&chain=arbitrum-one
-    - Base https://thegraph.com/explorer/subgraphs/BHWNsedAHtmTCzXxCCDfhPmm6iN9rxUhoRHdHKyujic3?view=Query&chain=arbitrum-one
+    - Base https://thegraph.com/explorer/subgraphs/5YYKGBcRkJs6tmDfB3RpHdbK2R5KBACHQebXVgbUcYQp?view=Query&chain=arbitrum-one
     - opBNB https://opbnb-mainnet-graph.nodereal.io/subgraphs/name/pancakeswap/exchange-v3
 
 17. **Exchange (StableSwap)**: Tracks all PancakeSwap Stableswap Exchange data with price, volume, liquidity

--- a/docs/pages/bug-bounty.md
+++ b/docs/pages/bug-bounty.md
@@ -24,5 +24,5 @@ https://immunefi.com/bounty/pancakeswap
 
 \*XSS reports are restricted to those that have an impact of prompting a user to sign a transaction or a redirect.
 
-All payouts are done by the **PancakeSwap** team and are pegged to the **USD** values set here and are payable in **CAKE** or **BUSD**.
+All payouts are done by the **PancakeSwap** team and are pegged to the **USD** values set here and are payable in **CAKE** or **USDT**.
 

--- a/docs/pages/contracts/cake/index.md
+++ b/docs/pages/contracts/cake/index.md
@@ -23,10 +23,6 @@ PancakeSwap uses LayerZero v1 OFT standard to bridge across chains. Bridge via t
 | Chain | Address |
 | ------------------------------------------ | ------------------------------------------ |
 | BSC testnet | 0x8d008B313C1d6C7fE2982F62d32Da7507cF43551 |
-| ETH Goerli | 0xc2C3eAbE0368a2Ea97f485b03D1098cdD7d0c081 |
-| Base Goerli | 0x052a99849Ef2e13a5CB28275862991671D4b6fF5 |
-| Linea Goerli | 0x2B3C5df29F73dbF028BA82C33e0A5A6e5800F75e |
-| opBNB | 0xa11B290B038C35711eB309268a2460754f730921 |
-| zkEVM | 0x2B3C5df29F73dbF028BA82C33e0A5A6e5800F75e |
+| opBNB testnet | 0xa11B290B038C35711eB309268a2460754f730921 |
 | Solana devnet | FwX9puvdxVAqLY8Cs7cMXPoZcPY8SdxMWkrnP7EPDiSw |
 

--- a/docs/pages/contracts/cross-chain-farming.md
+++ b/docs/pages/contracts/cross-chain-farming.md
@@ -1,6 +1,9 @@
 ---
-description: Contracts involved in cross-EVM-chains CAKE farming with Celer
+description: Cross-chain CAKE farming (deprecated)
 ---
 
 # Cross Chain Farming
 
+:::warning
+Cross Chain Farming via Celer has been deprecated. For current farming options, please refer to the [Infinity Farms](/contracts/infinity/overview/farms) documentation.
+:::

--- a/docs/pages/contracts/infinity/resources/addresses.mdx
+++ b/docs/pages/contracts/infinity/resources/addresses.mdx
@@ -3,7 +3,7 @@ import { Callout } from 'vocs/components'
 # Addresses 
 
 <Callout type="note">
-  PCS Infinity have been deployed on BNB Smart Chain and Base
+  PCS Infinity have been deployed on BNB Smart Chain, Base, and Monad
 </Callout>
 
 --- 

--- a/docs/pages/contracts/pottery.md
+++ b/docs/pages/contracts/pottery.md
@@ -1,2 +1,5 @@
 # Pottery
 
+:::warning
+Pottery has been deprecated and is no longer active. The subgraph is still available for historical data queries.
+:::

--- a/docs/pages/contracts/stableswap/stableswap-pools.md
+++ b/docs/pages/contracts/stableswap/stableswap-pools.md
@@ -2,6 +2,10 @@
 
 Current LP address and tokens for stable swap can be found below:
 
+:::warning
+BUSD pools (USDC-BUSD, USDT-BUSD) have been deprecated following the sunset of BUSD by Paxos in February 2024.
+:::
+
 ```json
  {
     pid: 135,
@@ -10,24 +14,6 @@ Current LP address and tokens for stable swap can be found below:
     token: bscTokens.usdt,
     quoteToken: bscTokens.usdc,
     stableSwapAddress: '0x3EFebC418efB585248A0D2140cfb87aFcc2C63DD',
-    infoStableSwapAddress: '0xa680d27f63Fa5E213C502d1B3Ca1EB6a3C1b31D6',
-  },
-  {
-    pid: 134,
-    lpSymbol: 'USDC-BUSD LP',
-    lpAddress: '0x1A77C359D0019cD8F4d36b7CDf5a88043D801072',
-    token: bscTokens.usdc,
-    quoteToken: bscTokens.busd,
-    stableSwapAddress: '0xc2F5B9a3d9138ab2B74d581fC11346219eBf43Fe',
-    infoStableSwapAddress: '0xa680d27f63Fa5E213C502d1B3Ca1EB6a3C1b31D6',
-  },
-  {
-    pid: 133,
-    lpSymbol: 'USDT-BUSD LP',
-    lpAddress: '0x36842F8fb99D55477C0Da638aF5ceb6bBf86aA98',
-    token: bscTokens.usdt,
-    quoteToken: bscTokens.busd,
-    stableSwapAddress: '0x169F653A54ACD441aB34B73dA9946e2C451787EF',
     infoStableSwapAddress: '0xa680d27f63Fa5E213C502d1B3Ca1EB6a3C1b31D6',
   },
 ```

--- a/docs/pages/contracts/universal-router/addresses.md
+++ b/docs/pages/contracts/universal-router/addresses.md
@@ -18,6 +18,7 @@ For usage details, refer to the [Perform a Swap guide](/contracts/infinity/guide
 | -------- | ------------------------------------------ |
 | BSC      | 0xd9C500DfF816a1Da21A48A732d3498Bf09dc9AEB |
 | Base     | 0xd9C500DfF816a1Da21A48A732d3498Bf09dc9AEB |
+| Monad    | 0x23682a588CF2601ACa977dF200938634c9F7d552 |
 
 **Testnet**
 
@@ -46,13 +47,7 @@ For usage details, refer to the [Perform a Swap guide](/contracts/infinity/guide
 | ---------------- | ------------------------------------------ |
 | BSC testnet      | 0x9A082015c919AD0E47861e5Db9A1c7070E81A2C7 |
 | Sepolia          | 0x55D32fa7Da7290838347bc97cb7fAD4992672255 |
-| Goerli           | 0xC46abF8B66Df4B9Eb0cC0cf6eba24226AC6E6285 |
 | Arbitrum Sepolia | 0xFE6508f0015C778Bdcc1fB5465bA5ebE224C9912 |
-| Arbitrum Goerli  | 0xa8EEA7aa6620712524d18D742821848e55E773B5 |
 | Base Sepolia     | 0xFE6508f0015C778Bdcc1fB5465bA5ebE224C9912 |
-| Base testnet     | 0xa8EEA7aa6620712524d18D742821848e55E773B5 |
 | Linea            | 0x9f3Cb8251492a069dBF0634C24e9De305d6946B8 |
-| opBNB            | 0xa8EEA7aa6620712524d18D742821848e55E773B5 |
-| zkEVM            | 0xa8EEA7aa6620712524d18D742821848e55E773B5 |
-| Scroll Sepolia   | 0xB89a6778D1efE7a5b7096757A21b810CC2886fa1 |
 | zkSync           | 0xCa97D1FAFCEa54EFc68d66eA914AB2F8Fbfe93c5 |

--- a/docs/pages/contracts/v3/addresses.md
+++ b/docs/pages/contracts/v3/addresses.md
@@ -6,14 +6,14 @@ description: Fork of Uniswap v3
 
 ## Core
 
-| Contract              | BSC, ETH, zkEVM, ARB, Linea, GOR, Base, opBNB, BSC TESTNET / MAINNET, Monad | zkSync                                     |
+| Contract              | BSC, ETH, zkEVM, ARB, Linea, Goerli (deprecated), Base, opBNB, BSC TESTNET / MAINNET, Monad | zkSync                                     |
 | --------------------- | -------------------------------------------------------------------- | ------------------------------------------ |
 | PancakeV3Factory      | 0x0BFbCF9fa4f9C56B0F40a671Ad40E0805A091865                           | 0x1BB72E0CbbEA93c08f535fc7856E0338D7F7a8aB |
 | PancakeV3PoolDeployer | 0x41ff9AA7e16B8B1a8a8dc4f0eFacd93D02d071c9                           | 0x7f71382044A6a62595D5D357fE75CA8199123aD6 |
 
 ## Periphery
 
-| Contract                   | BSC, ETH, zkEVM, Arbitrum, Linea, Base, opBNB, Monad | zkSync                                     | GOR, BSC TESTNET                           |
+| Contract                   | BSC, ETH, zkEVM, Arbitrum, Linea, Base, opBNB, Monad | zkSync                                     | Goerli (deprecated), BSC TESTNET                           |
 | -------------------------- | --------------------------------------------- | ------------------------------------------ | ------------------------------------------ |
 | SwapRouter (v3)            | 0x1b81D678ffb9C0263b24A97847620C99d213eB14    | 0xD70C70AD87aa8D45b8D59600342FB3AEe76E3c68 | 0x1b81D678ffb9C0263b24A97847620C99d213eB14 |
 | V3Migrator                 | 0xbC203d7f83677c7ed3F7acEc959963E7F4ECC5C2    | 0x556A72A7A3bB3bbd293D923e59b6B56898fB405D | 0x46A15B0b27311cedF172AB29E4f4766fbE7F4364 |
@@ -22,7 +22,7 @@ description: Fork of Uniswap v3
 | TickLens                   | 0x9a489505a00cE272eAa5e07Dba6491314CaE3796    | 0x7b08978FA77910f77d273c353C62b5BFB9E6D17B | 0xac1cE734566f390A94b00eb9bf561c2625BF44ea |
 | PancakeInterfaceMulticall  | 0xac1cE734566f390A94b00eb9bf561c2625BF44ea    | 0x2a76b93B9Cd441AE8aDA529e0e95826e00556351 | 0x3D00CdB4785F0ef20C903A13596e0b9B2c652227 |
 
-| Contract           | BSC, ETH, Linea                            | zkEVM, Linea, Base, opBNB                  | Arbitrum                                   | zkSync                                     | Monad | GOR, BSC TESTNET                           |
+| Contract           | BSC, ETH, Linea                            | zkEVM, Linea, Base, opBNB                  | Arbitrum                                   | zkSync                                     | Monad | Goerli (deprecated), BSC TESTNET                           |
 | ------------------ | ------------------------------------------ | ------------------------------------------ | ------------------------------------------ | ------------------------------------------ | ------------------------------------------ | ------------------------------------------ |
 | MixedRouteQuoterV1 | 0x678Aa4bF4E210cf2166753e054d5b7c31cc7fa86 | 0x4c650FB471fe4e0f476fD3437C3411B1122c4e3B | 0x3652Fc6EDcbD76161b8554388867d3dAb65eCA93 | 0x9B1edFB3848660402E4f1DC25733764e80aA627A | 0x77b482D9A4E391d682C857C630B8d869FdeE5c44 | 0xB048Bbc1Ee6b733FFfCFb9e9CeF7375518e25997 |
 | TokenValidator     | 0x864ED564875BdDD6F421e226494a0E7c071C06f8 | 0x556B9306565093C855AEA9AE92A594704c2Cd59e | 0x8be9EA9C6015985AB2F5A216093305A9AaEb8164 | 0x08529A4be615746ef31CdbeD46Ce556406787E2F | 0xfcB76dfDf9c79AE5d334C0E1901449c8A893DF22 | 0x678Aa4bF4E210cf2166753e054d5b7c31cc7fa86 |
@@ -42,7 +42,7 @@ Able to route to v3, v2 and stable pool
 
 | Chain | Address
 | ------------------------------------------ | ------------------------------------------ |
-| GOR, BSC testnet | 0x9a489505a00cE272eAa5e07Dba6491314CaE3796 | 
+| Goerli (deprecated), BSC testnet | 0x9a489505a00cE272eAa5e07Dba6491314CaE3796 | 
 
 
 ## MasterchefV3
@@ -52,17 +52,17 @@ Able to route to v3, v2 and stable pool
 | Chain | Address
 | ------------------------------------------ | ------------------------------------------ |
 | BSC, ETH | 0x556B9306565093C855AEA9AE92A594704c2Cd59e | 
-| zkEVM | 0xe9c7f3196ab8c09f6616365e8873daeb207c0391 | 
 | Arbitrum | 0x5e09ACf80C0296740eC5d6F643005a4ef8DaA694 | 
 | zkSync | 0x4c615E78c5fCA1Ad31e4d66eb0D8688d84307463 | 
 | Linea | 0x22E2f236065B780FA33EC8C4E58b99ebc8B55c57 | 
 | Base | 0xC6A2Db661D5a5690172d8eB0a7DEA2d3008665A3 |
+| opBNB | 0x05ddEDd07C51739d2aE21F6A9d97a8d69C2C3aaA |
 
 **Testnet**
 
 | Chain | Address
 | ------------------------------------------ | ------------------------------------------ |
-| GOR, BSC testnet | 0x4c650FB471fe4e0f476fD3437C3411B1122c4e3B | 
+| Goerli (deprecated), BSC testnet | 0x4c650FB471fe4e0f476fD3437C3411B1122c4e3B | 
 | zkEVM | 0xb66b07590B30d4E6E22e45Ddc83B06Bb018A7B44 | 
 | Arbitrum | 0x66A9870FF7707936B0B0278cF999C5f2Ac2e42F5 | 
 | zkSync | 0x3c6Aa61f72932aD5D7C917737367be32D5509e6f | 


### PR DESCRIPTION
## Summary

Audited the developer documentation against the current pancake-frontend codebase and fixed stale content across 9 files:

### Subgraph Endpoints
- Removed dead Arbitrum Goerli V2 Exchange endpoint (hosted service deprecated)
- Removed stale Polygon zkEVM subgraphs (V2, V3, MasterChefV3) — chain has been sunset
- Fixed Base V3 Exchange subgraph ID to match current codebase (`5YYKGBcRkJs6...` instead of `BHWNsedAHtm...`)

### Contract Addresses
- **Universal Router**: Added Monad Infinity UR address (`0x23682a...`), removed deprecated Goerli/zkEVM/opBNB/Scroll Sepolia testnet entries
- **V3 Addresses**: Marked Goerli columns as "(deprecated)", added opBNB to MasterchefV3, removed stale zkEVM MasterchefV3
- **Infinity Addresses**: Updated callout to include Monad deployment
- **CAKE Addresses**: Removed deprecated ETH Goerli, Base Goerli, Linea Goerli, and zkEVM testnet addresses

### Deprecation Cleanup
- **StableSwap Pools**: Removed deprecated BUSD pools (USDC-BUSD, USDT-BUSD), added deprecation notice
- **Bug Bounty**: Replaced BUSD with USDT for payouts (BUSD was sunset Feb 2024)
- **Cross-chain Farming**: Added deprecation notice — was an empty page referencing Celer
- **Pottery**: Added deprecation notice — was an empty page for a deprecated product

## Test plan
- [ ] Verify Vocs site builds successfully with `bun build`
- [ ] Check all updated subgraph links resolve correctly
- [ ] Cross-check contract addresses against on-chain deployments
- [ ] Verify Monad Universal Router address is deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)