### PR TITLE
docs: fix typo in Aptos contracts page (2026-04-20)

### DIFF
--- a/docs/pages/contracts-aptos/index.md
+++ b/docs/pages/contracts-aptos/index.md
@@ -8,7 +8,7 @@ description: >-
 
 ## Features
 
-PancakesSwap on Aptos! We have landed on Aptos and will continuously deploy more features.&#x20;
+PancakeSwap on Aptos! We have landed on Aptos and will continuously deploy more features.&#x20;
 
 [pancakeswap-v2](v2/overview.mdx)
 


### PR DESCRIPTION
## Documentation Sync — 2026-04-20 (auto-applied)

Low-risk mechanical fix applied automatically by the doc-sync agent.

### Typos fixed

- `docs/pages/contracts-aptos/index.md` line 11: `PancakesSwap` → `PancakeSwap`

### Pages updated

- `docs/pages/contracts-aptos/index.md`

---
Auto-applied by doc-sync agent (low-risk only). @ChefEric @chef-miso FYI.