### PR TITLE
docs: fix hook Permissions struct field names (2026-04-20) — high-risk

### DIFF
--- a/docs/pages/contracts/infinity/guides/develop-a-hook.mdx
+++ b/docs/pages/contracts/infinity/guides/develop-a-hook.mdx
@@ -119,10 +119,10 @@ contract VeCakeSwapDiscountHook is CLBaseHook { // [!code focus]
                 afterSwap: false,
                 beforeDonate: false,
                 afterDonate: false,
-                beforeSwapReturnsDelta: false,
-                afterSwapReturnsDelta: false,
-                afterAddLiquidityReturnsDelta: false,
-                afterRemoveLiquidityReturnsDelta: false
+                beforeSwapReturnDelta: false,
+                afterSwapReturnDelta: false,
+                afterAddLiquidityReturnDelta: false,
+                afterRemoveLiquidityReturnDelta: false
             })
         );
     }

--- a/docs/pages/contracts/infinity/overview/custom-layer-hook.mdx
+++ b/docs/pages/contracts/infinity/overview/custom-layer-hook.mdx
@@ -33,10 +33,10 @@ function getHooksRegistrationBitmap() external pure override returns (uint16) {
       afterDonate: false,
 
       // Hook return delta (documented below)
-      beforeSwapReturnsDelta: false,
-      afterSwapReturnsDelta: false,
-      afterAddLiquidityReturnsDelta: false,
-      afterRemoveLiquidityReturnsDelta: false
+      beforeSwapReturnDelta: false,
+      afterSwapReturnDelta: false,
+      afterAddLiquidityReturnDelta: false,
+      afterRemoveLiquidityReturnDelta: false
     })
   );
 }
@@ -72,10 +72,10 @@ function getHooksRegistrationBitmap() external pure override returns (uint16) {
     Permissions({
 
       // The 4 permissions around modifying return delta
-      beforeSwapReturnsDelta: false, // during beforeSwap 
-      afterSwapReturnsDelta: false, // during afterSwap 
-      afterAddLiquidityReturnsDelta: false, // during afterAddLiquidity 
-      afterRemoveLiquidityReturnsDelta: false // during afterRemoveLiquidity
+      beforeSwapReturnDelta: false, // during beforeSwap 
+      afterSwapReturnDelta: false, // during afterSwap 
+      afterAddLiquidityReturnDelta: false, // during afterAddLiquidity 
+      afterRemoveLiquidityReturnDelta: false // during afterRemoveLiquidity
     })
   );
 }


### PR DESCRIPTION
## Documentation Sync — 2026-04-20 (high-risk, needs review)

Scan target: Infinity hook code examples (re-check requested after the initial infinity-core scan).

### Changes applied

**Permissions struct field names (`beforeSwapReturnsDelta` → `beforeSwapReturnDelta`)**

Code examples in two pages used the field names with an extra `s` before `Delta`. The canonical field names in `CLBaseHook.Permissions` drop the `s`. A developer copying these examples would hit "Member not found" at compile time.

Files:
- `docs/pages/contracts/infinity/guides/develop-a-hook.mdx` — VeCakeSwapDiscountHook example (lines 122–125)
- `docs/pages/contracts/infinity/overview/custom-layer-hook.mdx` — intro Permissions block (lines 36–39) and the "Hook return delta" block (lines 75–78)

Both pages already use the CORRECT spelling in other code blocks earlier in the same files (e.g. `develop-a-hook.mdx` lines 49–52 in the CLCounterHook example). This PR makes all Permissions struct literals consistent.

### Important context for reviewers

There is a naming mismatch in the upstream source itself that looks suspicious but is real:
- **Struct field names** (in `CLBaseHook.Permissions`): `beforeSwapReturnDelta` (singular, no `s`)
- **Bitmap offset constants** (imported at the top of `CLBaseHook.sol`): `HOOKS_BEFORE_SWAP_RETURNS_DELTA_OFFSET` (plural, with `s`)

This PR only changes the struct field names in doc examples. No constant names are changed.

### Source verification

- `CLBaseHook.Permissions` struct with singular field names: [pancakeswap/infinity-hooks-template/src/pool-cl/CLBaseHook.sol](https://github.com/pancakeswap/infinity-hooks-template/blob/main/src/pool-cl/CLBaseHook.sol)

### Pages re-scanned (no drift)

- `docs/pages/contracts/infinity/guides/hook-examples/overwriting-amm-curve.mdx`
- `docs/pages/contracts/infinity/guides/hook-examples/taking-fee-via-hook.mdx`
- `trade/pancakeswap-infinity/hooks/README.md` (pancake-document)
- `trade/pancakeswap-infinity/hooks/dynamic-fee-hook.md` (pancake-document)

---
Auto-generated by doc-sync agent. Merge to apply; close to reject; comment to request changes. @ChefEric @chef-miso please review.