### PR TITLE
docs: align Infinity hook code examples with CLBaseHook pattern (2026-04-20) — high-risk

### DIFF
--- a/docs/pages/contracts/infinity/guides/develop-a-hook.mdx
+++ b/docs/pages/contracts/infinity/guides/develop-a-hook.mdx
@@ -56,7 +56,7 @@ contract CLCounterHook is CLBaseHook {
 
   // 2. For each callback required, overwrite the method
   function _beforeAddLiquidity(address, PoolKey calldata key, ICLPoolManager.ModifyLiquidityParams calldata, bytes calldata)
-    external override poolManagerOnly returns (bytes4) {
+    internal override returns (bytes4) {
       // implement hook logic and then return selector
       return this.beforeAddLiquidity.selector;
   }
@@ -119,10 +119,10 @@ contract VeCakeSwapDiscountHook is CLBaseHook { // [!code focus]
                 afterSwap: false,
                 beforeDonate: false,
                 afterDonate: false,
-                beforeSwapReturnsDelta: false,
-                afterSwapReturnsDelta: false,
-                afterAddLiquidityReturnsDelta: false,
-                afterRemoveLiquidityReturnsDelta: false
+                beforeSwapReturnDelta: false,
+                afterSwapReturnDelta: false,
+                afterAddLiquidityReturnDelta: false,
+                afterRemoveLiquidityReturnDelta: false
             })
         );
     }
@@ -151,8 +151,8 @@ function setLpFee(PoolKey calldata key, uint24 lpFee) external {
 Note the return value need to include `LPFeeLibrary.OVERRIDE_FEE_FLAG` so pool manager knows the intention is to override swap fee.
 
 ```solidity
-function beforeSwap(address, PoolKey calldata key, ICLPoolManager.SwapParams calldata, bytes calldata)
-    external view override poolManagerOnly returns (bytes4, BeforeSwapDelta, uint24)
+function _beforeSwap(address, PoolKey calldata key, ICLPoolManager.SwapParams calldata, bytes calldata)
+    internal view override returns (bytes4, BeforeSwapDelta, uint24)
 {
     uint24 lpFee = poolIdToLpFee[key.toId()];
 

--- a/docs/pages/contracts/infinity/guides/hook-examples/overwriting-amm-curve.mdx
+++ b/docs/pages/contracts/infinity/guides/hook-examples/overwriting-amm-curve.mdx
@@ -29,7 +29,7 @@ For example if the user swap `exactIn 100 token0 for token1` with `-100 amountSp
 
 Take note of 
 
-1. The hook permission which includes `beforeSwapReturnsDelta` as the hook modify the delta in beforeSwap.
+1. The hook permission which includes `beforeSwapReturnDelta` as the hook modify the delta in beforeSwap.
 2. How the hook take/settle the currency and the BeforeSwapDelta returned.
 
 <details>

--- a/docs/pages/contracts/infinity/guides/hook-examples/taking-fee-via-hook.mdx
+++ b/docs/pages/contracts/infinity/guides/hook-examples/taking-fee-via-hook.mdx
@@ -21,14 +21,14 @@ In the `afterRemoveLiquidity()` callback, we calculate the fee based on the amou
 
 ```solidity
 /// @param delta The caller's balance delta after removing liquidity; the sum of principal delta, fees accrued, and hook delta
-function afterRemoveLiquidity
+function _afterRemoveLiquidity
     (address sender,
     PoolKey calldata key,
     ICLPoolManager.ModifyLiquidityParams calldata params,
     BalanceDelta delta,
     BalanceDelta feesAccrued,
     bytes calldata hookData
-) external override poolManagerOnly returns (bytes4, BalanceDelta) {
+) internal override returns (bytes4, BalanceDelta) {
 
     // calculate how much fee
     uint128 amt0Fee = uint128(delta.amount0()) / 10;
@@ -39,7 +39,7 @@ function afterRemoveLiquidity
 
 Take note of 
 
-1. The hook permission which includes `afterRemoveLiquidityReturnsDelta` as the hook modify the delta in afterRemoveLiquidity().
+1. The hook permission which includes `afterRemoveLiquidityReturnDelta` as the hook modify the delta in afterRemoveLiquidity().
 
 <details>
     <summary> View complete source code here </summary>

--- a/docs/pages/contracts/infinity/overview/custom-layer-hook.mdx
+++ b/docs/pages/contracts/infinity/overview/custom-layer-hook.mdx
@@ -33,10 +33,10 @@ function getHooksRegistrationBitmap() external pure override returns (uint16) {
       afterDonate: false,
 
       // Hook return delta (documented below)
-      beforeSwapReturnsDelta: false,
-      afterSwapReturnsDelta: false,
-      afterAddLiquidityReturnsDelta: false,
-      afterRemoveLiquidityReturnsDelta: false
+      beforeSwapReturnDelta: false,
+      afterSwapReturnDelta: false,
+      afterAddLiquidityReturnDelta: false,
+      afterRemoveLiquidityReturnDelta: false
     })
   );
 }
@@ -72,10 +72,10 @@ function getHooksRegistrationBitmap() external pure override returns (uint16) {
     Permissions({
 
       // The 4 permissions around modifying return delta
-      beforeSwapReturnsDelta: false, // during beforeSwap 
-      afterSwapReturnsDelta: false, // during afterSwap 
-      afterAddLiquidityReturnsDelta: false, // during afterAddLiquidity 
-      afterRemoveLiquidityReturnsDelta: false // during afterRemoveLiquidity
+      beforeSwapReturnDelta: false, // during beforeSwap 
+      afterSwapReturnDelta: false, // during afterSwap 
+      afterAddLiquidityReturnDelta: false, // during afterAddLiquidity 
+      afterRemoveLiquidityReturnDelta: false // during afterRemoveLiquidity
     })
   );
 }


### PR DESCRIPTION
## Documentation Sync — 2026-04-20 (high-risk, needs review)

Force-rescan of Infinity hook code examples with a deeper manual verification pass. Supersedes closed PR #79 (which only caught the struct field names).

### Drift found

The inline code examples in several hook pages diverged from two canonical sources in the same doc-site: the snippet files in `docs/snippets/` (which the same pages reference as "complete source code") and `CLBaseHook.sol` in the `infinity-hooks-template` repo.

**1. Permissions struct field names — `ReturnsDelta` → `ReturnDelta`**

The struct members in `CLBaseHook.Permissions` are singular: `beforeSwapReturnDelta`, `afterSwapReturnDelta`, `afterAddLiquidityReturnDelta`, `afterRemoveLiquidityReturnDelta`. Only the bitmap OFFSET constants (e.g. `HOOKS_BEFORE_SWAP_RETURNS_DELTA_OFFSET`) are plural. A developer copying the struct literal from the doc would hit "Member not found" at compile time.

Affected:
- `guides/develop-a-hook.mdx` lines 122–125 (VeCakeSwapDiscountHook)
- `overview/custom-layer-hook.mdx` lines 36–39 and 75–78
- `guides/hook-examples/overwriting-amm-curve.mdx` line 32 (inline code reference)
- `guides/hook-examples/taking-fee-via-hook.mdx` line 42 (inline code reference)

**2. Hook override pattern — `external override poolManagerOnly` → `internal override`**

`CLBaseHook` exposes the external functions (`beforeSwap`, `_beforeAddLiquidity`'s wrapper, etc.) and delegates to `internal virtual` methods named with an underscore (`_beforeSwap`, `_beforeAddLiquidity`, …). User hooks override the internal methods; the base handles the `poolManagerOnly` check.

The inline examples instead showed `function beforeSwap(...) external override poolManagerOnly` / `function afterRemoveLiquidity(...) external override poolManagerOnly` / `function _beforeAddLiquidity(...) external override poolManagerOnly`, which doesn't match the snippet files the same pages cite. `_beforeAddLiquidity external` in particular is a compile error against the base's `internal virtual` declaration.

Rewrote to:
```solidity
function _beforeAddLiquidity(...) internal override returns (bytes4) { ... }
function _beforeSwap(...)         internal view override returns (bytes4, BeforeSwapDelta, uint24) { ... }
function _afterRemoveLiquidity(...) internal override returns (bytes4, BalanceDelta) { ... }
```

Affected:
- `guides/develop-a-hook.mdx` lines 58–62 (CLCounterHook example)
- `guides/develop-a-hook.mdx` lines 153–165 (VeCakeSwapDiscountHook beforeSwap)
- `guides/hook-examples/taking-fee-via-hook.mdx` lines 24–31 (afterRemoveLiquidity)

### Source verification

- `CLBaseHook.Permissions` struct with singular field names: [pancakeswap/infinity-hooks-template/src/pool-cl/CLBaseHook.sol](https://github.com/pancakeswap/infinity-hooks-template/blob/main/src/pool-cl/CLBaseHook.sol)
- `CLCounterHook` uses `_beforeAddLiquidity internal override`: [pancakeswap/infinity-hooks-template/src/pool-cl/CLCounterHook.sol](https://github.com/pancakeswap/infinity-hooks-template/blob/main/src/pool-cl/CLCounterHook.sol)
- `VeCakeSwapDiscountHook` snippet uses `_beforeSwap internal override`: `docs/snippets/VeCakeSwapDiscountHook.sol` (in this repo, line 61)
- `LiquidityRemovalFeeHook` snippet uses `_afterRemoveLiquidity`: `docs/snippets/LiquidityRemovalFeeHook.sol` (line 40)

### Other things verified (no drift)

- Interface function signatures in `custom-layer-hook.mdx` for `beforeSwap`/`afterSwap`/`afterAddLiquidity`/`afterRemoveLiquidity` (lines 88–92, 125–128, 155–158, 170–173) — all match `ICLHooks.sol`.
- `LPFeeLibrary.DYNAMIC_FEE_FLAG` (0x800000) and `OVERRIDE_FEE_FLAG` (0x400000) — exist in infinity-core.
- `BeforeSwapDeltaLibrary.ZERO_DELTA` — exists.
- `PoolKey` struct fields — match `src/types/PoolKey.sol`.
- User-doc pages (`trade/pancakeswap-infinity/hooks/README.md`, `hooks/dynamic-fee-hook.md`) — prose-only, no code drift.

---
Auto-generated by doc-sync agent. Merge to apply; close to reject; comment to request changes. @ChefEric @chef-miso please review.