### PR TITLE
docs: fix escaped-underscore audit URLs (2026-04-20)

### DIFF
--- a/docs/pages/contracts/farm-booster-bcake.md
+++ b/docs/pages/contracts/farm-booster-bcake.md
@@ -20,4 +20,4 @@ This factory contract helps deploy proxies for users to farm with bCAKE boost mu
 
 ## Audits
 
-[Peckshield's Farm Booster security audit](https://github.com/peckshield/publications/tree/master/audit\_reports/PeckShield-Audit-Report-PancakeSwap-FarmBooster-v1.0.pdf)
+[Peckshield's Farm Booster security audit](https://github.com/peckshield/publications/tree/master/audit_reports/PeckShield-Audit-Report-PancakeSwap-FarmBooster-v1.0.pdf)

--- a/docs/pages/contracts/fixed-term-staking-cake-pool.md
+++ b/docs/pages/contracts/fixed-term-staking-cake-pool.md
@@ -15,6 +15,6 @@ description: >-
 
 ## Audits
 
-[PeckShield's New CAKE Pool security audit](https://github.com/peckshield/publications/tree/master/audit\_reports/PeckShield-Audit-Report-PancakeSwap-CakePool-v1.0.pdf)
+[PeckShield's New CAKE Pool security audit](https://github.com/peckshield/publications/tree/master/audit_reports/PeckShield-Audit-Report-PancakeSwap-CakePool-v1.0.pdf)
 
 [Slowmist's New CAKE Pool security audit](https://github.com/slowmist/Knowledge-Base/blob/master/open-report-V2/smart-contract/SlowMist%20Audit%20Report%20-%20Pancakeswap-CakePool\_en-us.pdf)

--- a/docs/pages/contracts/lottery-v2/index.md
+++ b/docs/pages/contracts/lottery-v2/index.md
@@ -19,7 +19,7 @@ View the [PancakeSwap: Lottery contract on BscScan](https://bscscan.com/address/
 
 The PancakeSwap Lottery V2 has been audited twice so far. View the results below:
 
-[Peckshield's Lottery V2 Audit](https://github.com/peckshield/publications/blob/master/audit\_reports/PeckShield-Audit-Report-PancakeswapLottery-v1.0.pdf)
+[Peckshield's Lottery V2 Audit](https://github.com/peckshield/publications/blob/master/audit_reports/PeckShield-Audit-Report-PancakeswapLottery-v1.0.pdf)
 
 [Slowmist's Lottery V2 Audit](https://github.com/slowmist/Knowledge-Base/blob/master/open-report/Smart%20Contract%20Security%20Audit%20Report%20-%20PancakeSwap%20Lottery.pdf)
 

--- a/docs/pages/contracts/masterchef/addresses.md
+++ b/docs/pages/contracts/masterchef/addresses.md
@@ -26,6 +26,6 @@ Contract address: `0xa5f8C5Dbd5F286960b9d90548680aE5ebFf07652`
 
 ## Audits
 
-[PeckShield's New MasterChef security audit](https://github.com/peckshield/publications/tree/master/audit\_reports/PeckShield-Audit-Report-PancakeSwap-MasterChefV2-v1.0.pdf)
+[PeckShield's New MasterChef security audit](https://github.com/peckshield/publications/tree/master/audit_reports/PeckShield-Audit-Report-PancakeSwap-MasterChefV2-v1.0.pdf)
 
 [Slowmist's New MasterChef security audit](https://github.com/slowmist/Knowledge-Base/blob/master/open-report-V2/smart-contract/SlowMist%20Audit%20Report%20-%20MasterChef%20v2\_en-us.pdf)


### PR DESCRIPTION
## Documentation Sync — 2026-04-20 (auto-applied, low-risk)

Low-risk content quality fixes. All mechanical fixes where the correct value is unambiguous.

### Broken audit-report links fixed
Four PeckShield audit report URLs contained backslash-escaped underscores (`audit\_reports`) left over from GitBook migration. The backslash becomes a literal character in rendered links, breaking them. Removed the backslash so URLs resolve correctly.

### Pages updated
- docs/pages/contracts/farm-booster-bcake.md
- docs/pages/contracts/fixed-term-staking-cake-pool.md
- docs/pages/contracts/lottery-v2/index.md
- docs/pages/contracts/masterchef/addresses.md

---
Auto-applied by doc-sync agent (low-risk only). @ChefEric @chef-miso FYI.